### PR TITLE
Fix escape/unescape functions according to the RFC

### DIFF
--- a/lib/vobject/helpers.js
+++ b/lib/vobject/helpers.js
@@ -1,9 +1,13 @@
 
 exports.escape = function(str) {
   str = str || '';
-  return str.replace(/\n/g, '\\n').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/"/g, '\\"');
+  return str.replace(/[\\\n;,]/g, function(match) {
+    return '\\' + (match === '\n' ? 'n' : match);
+  });
 };
 
 exports.unescape = function(str) {
-  return str.replace(/\\n/g, '\n').replace(/\\;/g, ';').replace(/\\,/g, ',').replace(/\\"/g, '"');
+  return str.replace(/\\[\\nN;,]/g, function(match) {
+    return (match === '\\n' || match === '\\N') ? '\n' : match.substr(1);
+  });
 };

--- a/test/vobject/helpers.js
+++ b/test/vobject/helpers.js
@@ -18,16 +18,16 @@ describe('lib/vobject/helpers.js', function() {
       assert.equal(helpers.escape(str), 'this\\,that');
     });
 
-    it('should escape double quote', function() {
-      var str = 'this"that';
-      assert.equal(helpers.escape(str), 'this\\"that');
+    it('should escape backslash', function() {
+      var str = 'this\\that';
+      assert.equal(helpers.escape(str), 'this\\\\that');
     });
   });
 
   describe('unescape', function() {
     it('should unescape newline', function() {
-      var str = 'this\\nthat';
-      assert.equal(helpers.unescape(str), 'this\nthat');
+      var str = 'this\\nthat\\Nthose';
+      assert.equal(helpers.unescape(str), 'this\nthat\nthose');
     });
 
     it('should unescape semicolon', function() {
@@ -40,9 +40,9 @@ describe('lib/vobject/helpers.js', function() {
       assert.equal(helpers.unescape(str), 'this,that');
     });
 
-    it('should unescape double quote', function() {
-      var str = 'this\\"that';
-      assert.equal(helpers.unescape(str), 'this"that');
+    it('should unescape backslash', function() {
+      var str = 'this\\\\that';
+      assert.equal(helpers.unescape(str), 'this\\that');
     });
   });
 });


### PR DESCRIPTION
This pull request fix the issue where the current implementation doesn't correctly escape text properties.

According to the [RFC](http://tools.ietf.org/html/rfc5545#section-3.3.11), backslashes should be escaped, while double quotes should not. In addition, newline can be escaped as either `\n` or `\N`.