### PR TITLE
Update vobject-js output properties to ensure that the maximum line length of output properties doesn't exceed 75 characters in length.

### DIFF
--- a/lib/vobject/property.js
+++ b/lib/vobject/property.js
@@ -70,10 +70,18 @@ module.exports = function(name, value, parameters) {
 
     var line = ics.join('');
 
+    // Only the first line should be trimmed to 75
+    // every other line should be trimmed to 74
     var lines = [];
-    for (var i = 0; i < Math.ceil(line.length / 75); i++) {
-      var part = line.substring(i * 75, Math.min((i + 1) * 75, line.length));
+    var lineCount = Math.ceil(Math.max(0, line.length - 75) / 74) + 1;
+    for (var i = 0, o = 0; i < lineCount; i++) {
+      var offset = 74;
+      if (i === 0) {
+        offset = 75;
+      }
+      var part = line.substring(o, Math.min(o + offset, line.length));
       lines.push(part);
+      o += offset;
     }
     return lines.join('\r\n ');
   };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vobject",
   "description": "iCalendar VObject Manipulation in NodeJS",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Microsoft Outlook"
   },
@@ -21,13 +21,13 @@
     "url": "https://github.com/outlook/vobject-js/issues"
   },
   "dependencies": {
-    "moment-timezone": "0.5.10",
+    "moment-timezone": "^0.5.14",
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "mocha": "3.2.0",
-    "jshint": "2.9.4",
-    "nsp": "2.6.2"
+    "jshint": "^2.9.5",
+    "mocha": "^4.1.0",
+    "nsp": "^3.1.0"
   },
   "scripts": {
     "jshint": "./node_modules/.bin/jshint index.js lib/* test/*",

--- a/test/vobject/property.js
+++ b/test/vobject/property.js
@@ -140,7 +140,11 @@ describe('lib/vobject/property.js', function() {
 
     it('should fold at 75 characters', function() {
       var property = vobject.property('DESCRIPTION', 'Interactive Telecommunications Program\\nTisch School of the Arts\\nNew York University\\n721 Broadway\\, 4th Floor\\, South Elevators\\nNew York NY 10003\\n\\nTake the left elevators to the 4th Floor\\nThis event is free and open to the public\\nNo need to RSVP');
-      assert.equal(property.toICS(), 'DESCRIPTION:Interactive Telecommunications Program\\nTisch School of the Art\r\n s\\nNew York University\\n721 Broadway\\, 4th Floor\\, South Elevators\\nNew Yor\r\n k NY 10003\\n\\nTake the left elevators to the 4th Floor\\nThis event is free \r\n and open to the public\\nNo need to RSVP');
+      assert.equal(property.toICS(), 'DESCRIPTION:Interactive Telecommunications Program\\nTisch School of the Art\r\n s\\nNew York University\\n721 Broadway\\, 4th Floor\\, South Elevators\\nNew Yo\r\n rk NY 10003\\n\\nTake the left elevators to the 4th Floor\\nThis event is fre\r\n e and open to the public\\nNo need to RSVP');
+
+      property.toICS().split('\r\n').forEach(function(s) {
+        return assert.equal(s.length <= 75, true);
+      });
     });
   });
 });


### PR DESCRIPTION
This patch is meant to address a minor issue in the output format of rendered vobjects.

Each line that is long enough would end up being split to ensure that the content itself was never longer than **75 characters**.  Every line, after the first would be joined with the string '\r\n ' in order to ensure correct line endings and a continuation.  This means that wrapped lines would end up being **76 characters** in length instead of the **75** intended.

In addition to the aforementioned change, this also updates packages as specified by the test process to ensure they are up-to-date and pass the security checks.

As a result, the **patch** for the semantic version has also been updated.